### PR TITLE
Fix: Correct password error message display on class pages.

### DIFF
--- a/information_technology_2/class1.html
+++ b/information_technology_2/class1.html
@@ -52,7 +52,7 @@
         <li><a href="https://forms.gle/bxPzKGj1v17QSisn6" target="_blank" class="btn btn-custom d-block mb-2">第9回テスト（Google Forms）</a></li>
       </ul>
     </div>
-    <p id="error" class="hidden" style="color:red;">パスワードが間違っています。</p>
+    <p id="error" class="d-none" style="color:red;">パスワードが間違っています。</p>
   </div>
 
   <div class="footer">
@@ -64,10 +64,10 @@
       const input = document.getElementById("password").value;
       if (input === CORRECT_PASSWORD) {
         document.getElementById("content").style.display = "block";
-        document.getElementById("error").classList.add("hidden");
+        document.getElementById("error").classList.add("d-none");
       } else {
         document.getElementById("content").style.display = "none";
-        document.getElementById("error").classList.remove("hidden");
+        document.getElementById("error").classList.remove("d-none");
       }
     }
   </script>

--- a/information_technology_2/class2.html
+++ b/information_technology_2/class2.html
@@ -52,7 +52,7 @@
         <li><a href="https://forms.gle/aEivrpHjgESRbbCL8" target="_blank" class="btn btn-custom d-block mb-2">第9回テスト（Google Forms）</a></li>
       </ul>
     </div>
-    <p id="error" class="hidden" style="color:red;">パスワードが間違っています。</p>
+    <p id="error" class="d-none" style="color:red;">パスワードが間違っています。</p>
   </div>
 
   <div class="footer">
@@ -64,10 +64,10 @@
       const input = document.getElementById("password").value;
       if (input === CORRECT_PASSWORD) {
         document.getElementById("content").style.display = "block";
-        document.getElementById("error").classList.add("hidden");
+        document.getElementById("error").classList.add("d-none");
       } else {
         document.getElementById("content").style.display = "none";
-        document.getElementById("error").classList.remove("hidden");
+        document.getElementById("error").classList.remove("d-none");
       }
     }
   </script>

--- a/information_technology_3/class1.html
+++ b/information_technology_3/class1.html
@@ -54,7 +54,7 @@
       <li><a href="https://mega.nz/folder/4Zg1SaZR#0PxJ7DHZ6tbfPx3R7z2I8Q" target="_blank">Sit & Quest</a></li>
     </ul> -->
     </div>
-    <p id="error" class="hidden" style="color:red;">パスワードが間違っています。</p>
+    <p id="error" class="d-none" style="color:red;">パスワードが間違っています。</p>
   </div>
 
   <div class="footer">
@@ -66,10 +66,10 @@
       const input = document.getElementById("password").value;
       if (input === CORRECT_PASSWORD) {
         document.getElementById("content").style.display = "block";
-        document.getElementById("error").classList.add("hidden");
+        document.getElementById("error").classList.add("d-none");
       } else {
         document.getElementById("content").style.display = "none";
-        document.getElementById("error").classList.remove("hidden");
+        document.getElementById("error").classList.remove("d-none");
       }
     }
   </script>

--- a/information_technology_3/class2.html
+++ b/information_technology_3/class2.html
@@ -54,7 +54,7 @@
       <li><a href="https://mega.nz/folder/4Zg1SaZR#0PxJ7DHZ6tbfPx3R7z2I8Q" target="_blank">Sit & Quest</a></li>
     </ul> -->
     </div>
-    <p id="error" class="hidden" style="color:red;">パスワードが間違っています。</p>
+    <p id="error" class="d-none" style="color:red;">パスワードが間違っています。</p>
   </div>
 
   <div class="footer">
@@ -66,10 +66,10 @@
       const input = document.getElementById("password").value;
       if (input === CORRECT_PASSWORD) {
         document.getElementById("content").style.display = "block";
-        document.getElementById("error").classList.add("hidden");
+        document.getElementById("error").classList.add("d-none");
       } else {
         document.getElementById("content").style.display = "none";
-        document.getElementById("error").classList.remove("hidden");
+        document.getElementById("error").classList.remove("d-none");
       }
     }
   </script>


### PR DESCRIPTION
Previously, the error message "パスワードが間違っています。" on class-specific pages was always visible, or its visibility was not reliably controlled. This was due to using a non-standard `hidden` class that lacked a corresponding CSS `display: none;` rule.

This commit fixes the issue by:
1.  Changing the class of the error message paragraph `<p id="error">` from `hidden` to `d-none` in the HTML of all four class-specific pages. `d-none` is Bootstrap's standard utility class for `display: none !important;`.
2.  Updating the `checkPassword()` JavaScript function in these pages to use `classList.add("d-none")` and `classList.remove("d-none")` to control the visibility of the error message.

With these changes, the error message is now correctly hidden by default on page load and only becomes visible if you submit an incorrect password.