### PR TITLE
Fix: Correct header links and add ruby script to class pages.

### DIFF
--- a/information_technology_2/class1.html
+++ b/information_technology_2/class1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <script async="" src="https://rubyfuljs.s3.ap-northeast-1.amazonaws.com/rubyful.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>情報技術II 1組 - パスワード認証</title>

--- a/information_technology_2/class2.html
+++ b/information_technology_2/class2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <script async="" src="https://rubyfuljs.s3.ap-northeast-1.amazonaws.com/rubyful.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>情報技術II 2組 - パスワード認証</title>

--- a/information_technology_3/class1.html
+++ b/information_technology_3/class1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <script async="" src="https://rubyfuljs.s3.ap-northeast-1.amazonaws.com/rubyful.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>情報技術III 1組 - パスワード認証</title>

--- a/information_technology_3/class2.html
+++ b/information_technology_3/class2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+  <script async="" src="https://rubyfuljs.s3.ap-northeast-1.amazonaws.com/rubyful.js"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>情報技術III 2組 - パスワード認証</title>


### PR DESCRIPTION
This commit addresses two issues on the class-specific pages (e.g., information_technology_2/class1.html):

1.  **Header Navigation Links:**
    - I verified and ensured that the `href` attributes for the main navigation links (Home, parent course page, other course page) in the header navbar of all four class-specific pages use correct relative paths. No changes to link paths were ultimately needed as they were found to be correct from a previous update, but this re-confirms their state.

2.  **Missing Ruby/Furigana Functionality:**
    - The `rubyful.js` script, which provides ruby character functionality, was missing from the `<head>` of the class-specific pages.
    - I added `<script async="" src="https://rubyfuljs.s3.ap-northeast-1.amazonaws.com/rubyful.js"></script>` to the `<head>` of all four class-specific pages. This is expected to restore the ruby functionality, assuming the script works automatically or adds its own UI elements as it does on other pages.